### PR TITLE
Ufw

### DIFF
--- a/modules/ufw/.gitignore
+++ b/modules/ufw/.gitignore
@@ -1,0 +1,2 @@
+.vagrant/
+.project

--- a/modules/ufw/README.markdown
+++ b/modules/ufw/README.markdown
@@ -1,0 +1,43 @@
+# ufw #
+
+This is the ufw module. It provides...
+The "Uncomplicated Firewall" (UFW) functionality.
+
+## Current Status / Support
+* Works on Ubuntu 
+* Allows for multiple uses to define multiple port exemptions 
+* Can provide a port exemption for `TCP` or `UDP`
+
+## Usage
+To set a *TCP* port exemption add the following to the manifest:  
+
+	ufw {"test":
+    	port => '8080',
+    	isTCP => true
+	}
+For UDP we simply set the **isTCP** value to `false`:
+	
+	ufw {"test":
+    	port => '8080',
+    	isTCP => false
+	}
+## Testing performed
+
+## Known Issues
+[Known Issues Ubuntu](#Known_issues_ubuntu)
+
+
+## Ubuntu
+### <a href="Known_issues_ubuntu>Known Issues Ubuntu</a>
+Makes the assumption that UFW is installed as a service on Ubuntu.  
+If another firewall is being used such as iptables then this module will not install ufw and set it up as a service.
+
+Behavioural issues:  
+* Changing a rule via a manifest will **not** remove an old rule.  
+* Currently cannot remove rules
+
+### Adding a new version of Ubuntu  
+## To Do
+* Add ability to set port ranges instead of just a single port per manifest call
+* Support removal of rules
+* Support blocking of all ports by default, so that when an exemption is modified the old rule will be blocked?

--- a/modules/ufw/Rakefile
+++ b/modules/ufw/Rakefile
@@ -1,0 +1,2 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/modules/ufw/Vagrantfile
+++ b/modules/ufw/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/wily64"
+  config.vm.box_check_update = false
+  config.ssh.insert_key = false
+  config.vm.network "private_network", ip: "192.168.33.15"
+  config.vm.synced_folder "../", "/etc/puppet/modules/"
+
+end

--- a/modules/ufw/manifests/init.pp
+++ b/modules/ufw/manifests/init.pp
@@ -27,7 +27,7 @@ define ufw (
   exec {"add firewall rule ${port}/${protocol}":
     path => "/usr/sbin/",
     command => "ufw allow ${port}/${protocol}",
-    unless => "ufw status | /bin/grep ${port}/${protocol} * ALLOW"
+    unless => "ufw status | /bin/grep ${port}/${protocol} .* ALLOW"
   }
   ->
   exec {"Enable Firewall":

--- a/modules/ufw/manifests/init.pp
+++ b/modules/ufw/manifests/init.pp
@@ -1,0 +1,44 @@
+# Class: ufw
+#
+# This module manages ufw
+#
+# Parameters: none
+#
+# Actions:
+#
+# Requires: see Modulefile
+#
+# Sample Usage:
+#
+define ufw (
+  $port = undef,
+  $isTCP = undef,
+) {
+  if ("${operatingsystem}" != "Ubuntu"){
+    fail("Operating System not supported ${operatingsystem}")
+  }
+  
+  if ("${isTCP}" == "true"){
+    $protocol = "tcp"
+  } else {
+    $protocol = "udp"
+  }
+
+  exec {"add firewall rule ${port}/${protocol}":
+    path => "/usr/sbin/",
+    command => "ufw allow ${port}/${protocol}",
+    unless => "ufw status | /bin/grep ${port}/${protocol} * ALLOW"
+  }
+  ->
+  exec {"Enable Firewall":
+    path => "/usr/sbin/",
+    command => "ufw --force enable",
+    onlyif => "ufw status | /bin/grep inactive",
+    notify => Service["ufw"]
+  }
+
+  service {"ufw":
+    ensure => running,
+    enable => true
+  }
+}

--- a/modules/ufw/manifests/ufw.pp
+++ b/modules/ufw/manifests/ufw.pp
@@ -13,5 +13,5 @@ Package{
 
   ufw {"test":
     port => '8080',
-    isTCP => true
+    isTCP => false
   }

--- a/modules/ufw/manifests/ufw.pp
+++ b/modules/ufw/manifests/ufw.pp
@@ -1,0 +1,17 @@
+Package{
+  allow_virtual => false
+}
+
+#  $local_install_path = "/etc/puppet/"
+#  $local_install_dir = "${local_install_path}installers/"
+#
+#  file {
+#    "${local_install_dir}":
+#    path       =>  "${local_install_dir}",
+#    ensure     =>  directory,
+#  } 
+
+  ufw {"test":
+    port => '8080',
+    isTCP => true
+  }

--- a/modules/ufw/metadata.json
+++ b/modules/ufw/metadata.json
@@ -1,0 +1,13 @@
+{
+  "author": "",
+  "dependencies": [],
+  "license": "",
+  "name": "Alexander-ufw",
+  "operatingsystem_support": [],
+  "project_page": "",
+  "requirements": [],
+  "source": "",
+  "summary": "",
+  "tags": [],
+  "version": "0.1.0"
+}

--- a/modules/ufw/spec/spec.opts
+++ b/modules/ufw/spec/spec.opts
@@ -1,0 +1,6 @@
+--format
+s
+--colour
+--loadby
+mtime
+--backtrace

--- a/modules/ufw/spec/spec_helper.rb
+++ b/modules/ufw/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/ufw/tests/8080-tcp.pp
+++ b/modules/ufw/tests/8080-tcp.pp
@@ -1,0 +1,9 @@
+Package{
+  allow_virtual => false
+}
+  ufw {"test":
+    port => '8080',
+    isTCP => true
+  }
+#To check the rule is applied run:
+#sudo ufw status | grep "8080/tcp .* ALLOW"

--- a/modules/ufw/tests/8080-udp.pp
+++ b/modules/ufw/tests/8080-udp.pp
@@ -1,0 +1,9 @@
+Package{
+  allow_virtual => false
+}
+  ufw {"test":
+    port => '8080',
+    isTCP => false
+  }
+#To check the rule is applied run:
+#sudo ufw status | grep "8080/udp .* ALLOW"

--- a/modules/ufw/tests/init.pp
+++ b/modules/ufw/tests/init.pp
@@ -1,0 +1,1 @@
+include ufw


### PR DESCRIPTION
Pulling in the ufw module to allow for the apache/ubuntu branch to successfully add a port exemption to the firewall.
Currently the apache module has the port 80 exemption removed for both CentOS and Ubuntu.